### PR TITLE
Fix unicode errors in formatters under Python 2.7

### DIFF
--- a/prospector/__pkginfo__.py
+++ b/prospector/__pkginfo__.py
@@ -1,3 +1,3 @@
 # -*- coding: utf-8 -*-
-__version_info__ = (1, 2, 0)
+__version_info__ = (1, 2, 1)
 __version__ = '.'.join(map(str, __version_info__))

--- a/prospector/formatters/emacs.py
+++ b/prospector/formatters/emacs.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from prospector.formatters.text import TextFormatter
 
 

--- a/prospector/formatters/grouped.py
+++ b/prospector/formatters/grouped.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from collections import defaultdict
 
 from prospector.formatters.text import TextFormatter

--- a/prospector/formatters/json.py
+++ b/prospector/formatters/json.py
@@ -1,7 +1,6 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import json
-
 from datetime import datetime
 
 from prospector.formatters.base import Formatter

--- a/prospector/formatters/pylint.py
+++ b/prospector/formatters/pylint.py
@@ -1,5 +1,8 @@
+from __future__ import unicode_literals
+
 import os
 import re
+
 from prospector.formatters.base import Formatter
 
 

--- a/prospector/formatters/text.py
+++ b/prospector/formatters/text.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from prospector.formatters.base import Formatter
 
 

--- a/prospector/formatters/vscode.py
+++ b/prospector/formatters/vscode.py
@@ -1,5 +1,8 @@
+from __future__ import unicode_literals
+
 import os
 import re
+
 from prospector.formatters.base import Formatter
 
 

--- a/prospector/formatters/xunit.py
+++ b/prospector/formatters/xunit.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from prospector.formatters.base import Formatter
 from xml.dom.minidom import Document
 

--- a/prospector/formatters/yaml.py
+++ b/prospector/formatters/yaml.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, unicode_literals
 
 import yaml
 

--- a/prospector/run.py
+++ b/prospector/run.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import
 import os.path
 import sys
 from datetime import datetime
+from io import open
 
 from prospector import blender, postfilter, tools
 from prospector.config import configuration as cfg
@@ -133,7 +134,7 @@ class Prospector(object):
             if not output_files:
                 self.write_to(formatter, sys.stdout)
             for output_file in output_files:
-                with open(output_file, 'w+') as target:
+                with open(output_file, 'w+', encoding='UTF8') as target:
                     self.write_to(formatter, target)
 
     def write_to(self, formatter, target):
@@ -143,7 +144,7 @@ class Prospector(object):
             messages=not self.config.summary_only,
             profile=self.config.show_profile
         ))
-        target.write('\n')
+        target.write(u'\n')
 
 
 


### PR DESCRIPTION
When running prospector under Python 2.7 with files that contain unicode characters, the formatters would error out. I moved all the formatters to use unicode literals to avoid this bug and convert it usion io.open upon writing.

This was manually tested using our CI linter scripts.